### PR TITLE
Add configurable accuracy in Makefile

### DIFF
--- a/numpy/umath/Makefile
+++ b/numpy/umath/Makefile
@@ -1,12 +1,25 @@
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2018-2019 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 CC = icc
 CFLAGS = -qopenmp -xCORE-AVX2 -axCOMMON-AVX512 -O3 \
-		 -g -fp-model precise -fimf-precision=high -lmkl_rt
+		 -g -lmkl_rt
 
 PYTHON ?= python
+
+ACC ?= la
+ifeq ($(ACC), ha)
+	CFLAGS += -fimf-precision=high -D_VML_ACCURACY_HA_
+	CFLAGS += -fp-model precise
+endif
+ifeq ($(ACC), la)
+	CFLAGS += -fimf-precision=medium -D_VML_ACCURACY_LA_
+endif
+ifeq ($(ACC), ep)
+	CFLAGS += -fimf-precision=low -fimf-domain-exclusion=31 -D_VML_ACCURACY_EP_
+endif
+
 
 all: umath_precise
 	./umath_precise

--- a/numpy/umath/Makefile
+++ b/numpy/umath/Makefile
@@ -20,17 +20,22 @@ ifeq ($(ACC), ep)
 	CFLAGS += -fimf-precision=low -fimf-domain-exclusion=31 -D_VML_ACCURACY_EP_
 endif
 
+TARGET=umath_$(ACC)
 
-all: umath_precise
-	./umath_precise
+
+all: $(TARGET)
+	./$(TARGET)
 
 clean:
-	rm -f umath_precise umath_bench.c
+	rm -f umath_ha umath_la umath_ep umath_bench.c
 
-umath_precise: umath_bench.c
-	$(CC) umath_bench.c $(CPPFLAGS) $(CFLAGS) -o umath_precise
+compile: $(TARGET)
+
+
+$(TARGET): umath_bench.c
+	$(CC) umath_bench.c $(CPPFLAGS) $(CFLAGS) -o $(TARGET)
 
 umath_bench.c: umath_bench.c.src
 	$(PYTHON) -m numpy.distutils.conv_template umath_bench.c.src
 
-.PHONY: all clean
+.PHONY: all clean compile


### PR DESCRIPTION
Adds Make variable `ACC` to umath_bench like in [BlackScholes_bench](https://github.com/IntelPython/BlackScholes_bench/blob/master/GNUmakefile#L71).