### PR TITLE
Linear algebra: Add --verbose mode to verify result

### DIFF
--- a/numpy/linalg/Makefile
+++ b/numpy/linalg/Makefile
@@ -3,13 +3,20 @@
 # SPDX-License-Identifier: MIT
 
 CXX = icc
-CXXFLAGS = -O3 -g -xCORE-AVX2 -axCOMMON-AVX512 -qopenmp
-override CXXFLAGS += -std=c++11
+CXXFLAGS = -O3 -g -xCORE-AVX2 -axCOMMON-AVX512 -qopenmp \
+		   -qopt-report=5 -qopt-report-phase=openmp,par,vec
 LDFLAGS = -lmkl_rt -qopenmp
 
 TARGET = linalg
 BENCHES = cholesky det dot eig inv lu qr svd
 SOURCES = $(addsuffix .cc,$(BENCHES)) linalg.cc
+
+ifneq ($(CONDA_PREFIX),)
+	LDFLAGS += -L$(CONDA_PREFIX)/lib
+	CXXFLAGS += -I$(CONDA_PREFIX)/include
+endif
+
+override CXXFLAGS += -std=c++11
 
 CLANG_FORMAT = clang-format
 
@@ -17,7 +24,7 @@ $(TARGET): $(SOURCES:.cc=.o)
 	$(CXX) $^ -o $@ $(LDFLAGS)
 
 clean:
-	rm -f $(TARGET) *.o
+	rm -f $(TARGET) *.o *.optrpt
 
 format:
 	$(CLANG_FORMAT) -i $(SOURCES)

--- a/numpy/linalg/bench.h
+++ b/numpy/linalg/bench.h
@@ -6,6 +6,9 @@
 
 #pragma once
 #include <algorithm>
+#include <iostream>
+#include <cstdio>
+#include <complex>
 
 using namespace std;
 
@@ -75,7 +78,62 @@ class Bench {
         return mat;
     }
 
+    void print_scalar(double x) {
+        printf("% .3f", x);
+    }
+
+    void print_scalar(complex<double> x) {
+        print_scalar(x.real());
+        printf(" + ");
+        print_scalar(x.imag());
+        printf("i");
+    }
+
+    template<typename T>
+    void print_mat(char mode, T *x, int m, int n) {
+        // If mode == 'r', treat it as row-major
+        // If mode == 'c', treat it as col-major
+        printf("[");
+        for (int i = 0; i < m; i++) {
+            if (i > 0)
+                printf(" ");
+            printf("[");
+            for (int j = 0; j < n; j++) {
+                T num;
+                if (mode == 'r')
+                    num = x[i*n+j];
+                else if (mode == 'c')
+                    num = x[j*m+i];
+                print_scalar(num);
+                if (j < n-1)
+                    printf(", ");
+            }
+            printf("]");
+            if (i < m-1)
+                printf(",\n");
+        }
+        printf("]\n");
+    }
+
+    template<typename T>
+    bool mat_equal(const T *a, const T *b, int n, double tol) {
+        for (int i = 0; i < n; i++)
+            if (abs(a[i] - b[i]) > tol)
+                return false;
+
+        return true;
+    }
+
+    template<typename T>
+    bool mat_equal(const T *a, const T *b, int n) {
+        return mat_equal(a, b, n, 0.00000000000001);
+    }
+
     virtual void make_args(int size) = 0;
     virtual void copy_args() = 0;
+    virtual void clean_args() = 0;
+    virtual void print_args() = 0;
+    virtual void print_result() = 0;
     virtual void compute() = 0;
+    virtual bool test() {return false;};
 };

--- a/numpy/linalg/cholesky.cc
+++ b/numpy/linalg/cholesky.cc
@@ -5,7 +5,23 @@
  */
 
 #include "cholesky.h"
+#include <iostream>
 #include <cstring>
+
+static const double x_mat_test[] = {
+     5.551063927745538,  0.034194385271978, -0.276508795460738,
+     0.034194385271978,  4.704686460853461,  0.087572555571367,
+    -0.276508795460738,  0.087572555571367,  6.07658590927362 
+};
+
+static const double r_mat_test[] = {
+     2.356069593145656,  0.               ,  0.               ,
+     0.014513317166631,  2.16898036516661 ,  0.               ,
+    -0.117360198639788,  0.041160281019929,  2.461933858639425
+};
+
+static const int test_size = 3;
+
 
 Cholesky::Cholesky() {
     x_mat = r_mat = 0;
@@ -27,8 +43,8 @@ void Cholesky::make_args(int size) {
     for (int i = 0; i < n; i++) {
         r_mat[i * n + i] = 1;
     }
-    cblas_dsyrk(CblasColMajor, CblasUpper, CblasNoTrans, n, n, 1.0, x_mat, lda,
-                n, r_mat, lda);
+    cblas_dgemm(CblasColMajor, CblasNoTrans, CblasTrans, n, n, n, 1.0, x_mat,
+                n, x_mat, n, n, r_mat, n);
 
     // we now have r_mat = x_mat * x_mat' + n * np.eye(n)
     // copy back into x_mat
@@ -43,11 +59,43 @@ void Cholesky::compute() {
     // compute cholesky decomposition
     int info = LAPACKE_dpotrf(LAPACK_COL_MAJOR, 'U', n, r_mat, lda);
     assert(info == 0);
+
+    // we only want an upper triangular matrix
+    for (int i = 0; i < n-1; i++) {
+        memset(&r_mat[i * n + i + 1], 0, (n - i - 1) * sizeof(*r_mat));
+    }
 }
 
-Cholesky::~Cholesky() {
+bool Cholesky::test() {
+    clean_args();
+    make_args(test_size);
+    memcpy(x_mat, x_mat_test, mat_size * sizeof(*x_mat));
+    copy_args();
+    compute();
+
+    return mat_equal(r_mat, r_mat_test, mat_size);
+}
+
+
+void Cholesky::print_args() {
+    std::cout << "Cholesky decomposition, A = LL*, of a "
+        << "Hermitian positive-definite matrix A." << std::endl;
+    std::cout << "A = " << std::endl;
+    print_mat('c', x_mat, n, n);
+}
+
+void Cholesky::print_result() {
+    std::cout << "L = " << std::endl;
+    print_mat('c', r_mat, n, n);
+}
+
+void Cholesky::clean_args() {
     if (r_mat)
         mkl_free(r_mat);
     if (x_mat)
         mkl_free(x_mat);
+}
+
+Cholesky::~Cholesky() {
+    clean_args();
 }

--- a/numpy/linalg/cholesky.h
+++ b/numpy/linalg/cholesky.h
@@ -12,7 +12,11 @@ class Cholesky : public Bench {
     ~Cholesky();
     void make_args(int size);
     void copy_args();
+    void clean_args();
+    void print_args();
+    void print_result();
     void compute();
+    bool test();
 
   private:
     double *x_mat, *r_mat;

--- a/numpy/linalg/det.cc
+++ b/numpy/linalg/det.cc
@@ -5,7 +5,17 @@
  */
 
 #include "det.h"
+#include <iostream>
 #include <cstring>
+
+static const double x_mat_test[] = {
+     0.470442000675409, -0.291482508170914, -0.44183986349643 ,
+    -0.176333746005435,  0.007410393215614, -0.739195206041762,
+     0.481736547564898,  0.805743972141035, -0.468344563609981
+};
+
+static const double result_test = 0.4707855751774963;
+static const int test_size = 3;
 
 Det::Det() {
     r_mat = x_mat = 0;
@@ -17,7 +27,7 @@ void Det::make_args(int size) {
     m = size;
     mn_min = min(m, n);
     lda = size;
-    int mat_size = m * n;
+    mat_size = m * n;
     assert(m == n);
 
     // input matrix
@@ -28,7 +38,7 @@ void Det::make_args(int size) {
     assert(ipiv);
 
     // matrix for result
-    r_mat = make_random_mat(mat_size);
+    r_mat = make_mat(mat_size);
 
     copy_args();
 }
@@ -39,22 +49,46 @@ void Det::copy_args() {
 
 void Det::compute() {
     // compute pivoted lu decomposition
-    int info = LAPACKE_dgetrf(LAPACK_ROW_MAJOR, m, n, r_mat, lda, ipiv);
+    int info = LAPACKE_dgetrf(LAPACK_COL_MAJOR, m, n, r_mat, lda, ipiv);
     assert(info == 0);
 
     double t = 1.0;
     int i, j;
     for (i = 0, j = 0; i < mn_min; i++, j += lda + 1) {
-        t *= (ipiv[i] == i) ? r_mat[j] : -r_mat[j];
+        t *= (ipiv[i] == i+1) ? r_mat[j] : -r_mat[j];
     }
     result = t;
 }
 
-Det::~Det() {
+bool Det::test() {
+    clean_args();
+    make_args(test_size);
+    memcpy(x_mat, x_mat_test, mat_size * sizeof(*x_mat));
+    copy_args();
+    compute();
+
+    return mat_equal(&result, &result_test, 1);
+}
+
+void Det::print_args() {
+    std::cout << "Determinant of " << n << "x" << n << " matrix A." << std::endl;
+    std::cout << "A =" << std::endl;
+    print_mat('c', x_mat, n, n);
+}
+
+void Det::print_result() {
+    std::cout << "det(A) = " << result << std::endl;
+}
+
+void Det::clean_args() {
     if (r_mat)
         mkl_free(r_mat);
     if (ipiv)
         mkl_free(ipiv);
     if (x_mat)
         mkl_free(x_mat);
+}
+
+Det::~Det() {
+    clean_args();
 }

--- a/numpy/linalg/det.h
+++ b/numpy/linalg/det.h
@@ -12,6 +12,10 @@ class Det : public Bench {
     ~Det();
     void make_args(int size);
     void copy_args();
+    void clean_args();
+    bool test();
+    void print_args();
+    void print_result();
     void compute();
 
   private:

--- a/numpy/linalg/dot.cc
+++ b/numpy/linalg/dot.cc
@@ -5,13 +5,34 @@
  */
 
 #include "dot.h"
+#include <iostream>
 #include <cstring>
+
+static const double a_mat_test[] = {
+     0.470442000675409, -0.176333746005435,  0.481736547564898,
+    -0.291482508170914,  0.007410393215614,  0.805743972141035,
+    -0.44183986349643 , -0.739195206041762, -0.468344563609981
+};
+
+static const double b_mat_test[] = {
+    -0.279551412836935, -1.866235595807669,  0.949267732307811,
+     0.393910888693485,  0.357832357041521,  1.430099195743549,
+    -0.202579028296422, -1.225349132812327,  0.535350173863021
+};
+
+static const double r_mat_test[] = {
+    -0.298562230242867, -1.531348988185161,  0.452298407313714,
+    -0.078823449378468, -0.44069096675697 ,  0.165257833413781,
+    -0.072783295837747,  1.133954922888981, -1.727275138478663
+};
+
+static const int test_size = 3;
 
 Dot::Dot() {
     a_mat = b_mat = c_mat = r_mat = 0;
 }
 
-Dot::~Dot() {
+void Dot::clean_args() {
     if (a_mat)
         mkl_free(a_mat);
     if (b_mat)
@@ -20,6 +41,10 @@ Dot::~Dot() {
         mkl_free(c_mat);
     if (r_mat)
         mkl_free(r_mat);
+}
+
+Dot::~Dot() {
+    clean_args();
 }
 
 void Dot::make_args(int size) {
@@ -45,3 +70,29 @@ void Dot::compute() {
     cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, n, n, k, alpha,
                 a_mat, k, b_mat, n, beta, r_mat, n);
 }
+
+bool Dot::test() {
+    clean_args();
+    make_args(test_size);
+    memcpy(a_mat, a_mat_test, m * k * sizeof(*a_mat));
+    memcpy(b_mat, b_mat_test, k * n * sizeof(*b_mat));
+    copy_args();
+    compute();
+
+    return mat_equal(r_mat, r_mat_test, m * n);
+}
+
+
+void Dot::print_args() {
+    std::cout << "Matrix multiplication A * B." << std::endl;
+    std::cout << "A =" << std::endl;
+    print_mat('r', a_mat, m, k);
+    std::cout << "B =" << std::endl;
+    print_mat('r', b_mat, k, n);
+}
+
+void Dot::print_result() {
+    std::cout << "A * B =" << std::endl;
+    print_mat('r', r_mat, m, n);
+}
+

--- a/numpy/linalg/dot.h
+++ b/numpy/linalg/dot.h
@@ -12,6 +12,10 @@ class Dot : public Bench {
     ~Dot();
     void make_args(int size);
     void copy_args();
+    void clean_args();
+    bool test();
+    void print_args();
+    void print_result();
     void compute();
 
   private:

--- a/numpy/linalg/eig.cc
+++ b/numpy/linalg/eig.cc
@@ -8,6 +8,41 @@
 #include <cstring>
 #include <iostream>
 
+static const double a_mat_test[] = {
+     0.470442000675409, -0.291482508170914, -0.44183986349643 ,
+    -0.176333746005435,  0.007410393215614, -0.739195206041762,
+     0.481736547564898,  0.805743972141035, -0.468344563609981
+};
+
+static const std::complex<double> w_vec_complex_test[] = {
+    { 0.558344640162537,  0.               },
+    {-0.274418404940748,  0.876285061400947},
+    {-0.274418404940748, -0.876285061400947}
+};
+
+static const std::complex<double> vr_mat_complex_test[] = {
+    {-0.870718618937641,  0.               },
+    { 0.491334396303628,  0.               },
+    { 0.020966583991578,  0.               },
+    { 0.12292498568887 ,  0.296216896839797},
+    { 0.107429842088307,  0.640393071981176},
+    {-0.689565472096294,  0.               },
+    { 0.12292498568887 , -0.296216896839797},
+    { 0.107429842088307, -0.640393071981176},
+    {-0.689565472096294, -0.               }
+};
+
+static const int test_size = 3;
+
+// We set these to zero, because the expectation is complex
+// eigenvalues and eigenvectors for this test input
+static const double wr_vec_test[] = {0., 0., 0.};
+static const double vr_mat_test[] = {
+    0., 0., 0.,
+    0., 0., 0.,
+    0., 0., 0.
+};
+
 Eig::Eig() {
     a_mat = r_mat = vl_mat = vr_mat = wr_vec = wi_vec = 0;
     vr_mat_complex = 0;
@@ -32,9 +67,9 @@ void Eig::make_args(int size) {
 
     // complex eigenvalues and eigenvectors
     w_vec_complex =
-        (double _Complex *) mkl_malloc(n * sizeof(*w_vec_complex), 64);
+        (std::complex<double> *) mkl_malloc(n * sizeof(*w_vec_complex), 64);
     vr_mat_complex =
-        (double _Complex *) mkl_malloc(mat_size * sizeof(*vr_mat_complex), 64);
+        (std::complex<double> *) mkl_malloc(mat_size * sizeof(*vr_mat_complex), 64);
 }
 
 void Eig::copy_args() {
@@ -55,11 +90,9 @@ void Eig::compute() {
     // Are all eigenvalues purely real? If so, we need not do anything.
     only_real = true;
     for (int i = 0; i < n; i++) {
-        if (wi_vec[i] != 0.0) {
+        w_vec_complex[i] = std::complex<double>(wr_vec[i], wi_vec[i]);
+        if (wi_vec[i] != 0.0)
             only_real = false;
-            break;
-        }
-        w_vec_complex[i] = CMPLX(wr_vec[i], wi_vec[i]);
     }
 
     if (!only_real) {
@@ -73,20 +106,58 @@ void Eig::compute() {
             if (wi_vec[i] != 0.0) {
                 // Copy real and imaginary parts
                 for (int j = 0; j < n; j++) {
-                    cvec[j] = CMPLX(rvec[j], rvec[n + j]);
-                    cvec[n + j] = CMPLX(rvec[j], -rvec[n + j]);
+                    cvec[j] = std::complex<double>(rvec[j], rvec[n + j]);
+                    cvec[n + j] = std::complex<double>(rvec[j], -rvec[n + j]);
                 }
                 i++;
+                cvec += n;
+                rvec += n;
             } else {
                 for (int j = 0; j < n; j++) {
-                    cvec[j] = CMPLX(rvec[j], 0);
+                    cvec[j] = std::complex<double>(rvec[j], 0);
                 }
             }
         }
     }
 }
 
-Eig::~Eig() {
+bool Eig::test() {
+    clean_args();
+    make_args(test_size);
+    memcpy(a_mat, a_mat_test, mat_size * sizeof(*a_mat));
+    copy_args();
+    compute();
+
+    if (only_real)
+        return mat_equal(wr_vec, wr_vec_test, n)
+            && mat_equal(vr_mat, vr_mat_test, mat_size);
+    else
+        return mat_equal(w_vec_complex, w_vec_complex_test, n)
+            && mat_equal(vr_mat_complex, vr_mat_complex_test, mat_size);
+}
+
+
+void Eig::print_args() {
+    std::cout << "Eigenvalues and eigenvectors of " <<
+        n << "*" << n << " matrix A." << std::endl;
+    std::cout << "A =" << std::endl;
+    print_mat('c', a_mat, n, n);
+}
+
+void Eig::print_result() {
+    std::cout << "Eigenvalues =" << std::endl;
+    if (only_real)
+        print_mat('c', wr_vec, 1, n);
+    else
+        print_mat('c', w_vec_complex, 1, n);
+    std::cout << "Eigenvectors =" << std::endl;
+    if (only_real)
+        print_mat('c', vr_mat, n, n);
+    else
+        print_mat('c', vr_mat_complex, n, n);
+}
+
+void Eig::clean_args() {
     if (a_mat)
         mkl_free(a_mat);
     if (vl_mat)
@@ -101,4 +172,8 @@ Eig::~Eig() {
         mkl_free(w_vec_complex);
     if (vr_mat_complex)
         mkl_free(vr_mat_complex);
+}
+
+Eig::~Eig() {
+    clean_args();
 }

--- a/numpy/linalg/eig.h
+++ b/numpy/linalg/eig.h
@@ -5,7 +5,7 @@
  */
 
 #include "bench.h"
-#include <complex.h>
+#include <complex>
 
 class Eig : public Bench {
   public:
@@ -13,11 +13,15 @@ class Eig : public Bench {
     ~Eig();
     void make_args(int size);
     void copy_args();
+    void clean_args();
+    bool test();
+    void print_args();
+    void print_result();
     void compute();
 
   private:
     double *a_mat, *r_mat, *vl_mat, *vr_mat, *wr_vec, *wi_vec;
-    double _Complex *vr_mat_complex, *w_vec_complex;
+    std::complex<double> *vr_mat_complex, *w_vec_complex;
     int n, lda, ldvl, ldvr, mat_size;
     bool only_real;
 };

--- a/numpy/linalg/inv.cc
+++ b/numpy/linalg/inv.cc
@@ -5,7 +5,21 @@
  */
 
 #include "inv.h"
+#include <iostream>
 #include <cstring>
+
+static const double x_mat_test[] = {
+     0.470442000675409, -0.291482508170914, -0.44183986349643 ,
+    -0.176333746005435,  0.007410393215614, -0.739195206041762,
+     0.481736547564898,  0.805743972141035, -0.468344563609981
+};
+
+static const double r_mat_test[] = {
+     1.257751926455496, -1.046174905778333,  0.46462060722515 ,
+    -0.931809131348847, -0.01588524263938 ,  0.904147816602771,
+    -0.309375898184227, -1.103418649248418, -0.101770412852239
+};
+static const int test_size = 3;
 
 Inv::Inv() {
     x_mat = 0;
@@ -13,13 +27,17 @@ Inv::Inv() {
     ipiv = 0;
 }
 
-Inv::~Inv() {
+void Inv::clean_args() {
     if (r_mat)
         mkl_free(r_mat);
     if (ipiv)
         mkl_free(ipiv);
     if (x_mat)
         mkl_free(x_mat);
+}
+
+Inv::~Inv() {
+    clean_args();
 }
 
 void Inv::make_args(int size) {
@@ -54,4 +72,25 @@ void Inv::compute() {
 
     info = LAPACKE_dgetri(LAPACK_ROW_MAJOR, n, r_mat, lda, ipiv);
     assert(info == 0);
+}
+
+bool Inv::test() {
+    clean_args();
+    make_args(test_size);
+    memcpy(x_mat, x_mat_test, mat_size * sizeof(*x_mat));
+    copy_args();
+    compute();
+
+    return mat_equal(r_mat, r_mat_test, mat_size);
+}
+
+void Inv::print_args() {
+    std::cout << "Inverse of " << m << "*" << n << " matrix A." << std::endl;
+    std::cout << "A =" << std::endl;
+    print_mat('r', x_mat, m, n);
+}
+
+void Inv::print_result() {
+    std::cout << "A**-1 =" << std::endl;
+    print_mat('r', r_mat, m, n);
 }

--- a/numpy/linalg/inv.h
+++ b/numpy/linalg/inv.h
@@ -12,6 +12,10 @@ class Inv : public Bench {
     ~Inv();
     void make_args(int size);
     void copy_args();
+    void clean_args();
+    bool test();
+    void print_args();
+    void print_result();
     void compute();
 
   private:

--- a/numpy/linalg/lu.cc
+++ b/numpy/linalg/lu.cc
@@ -5,7 +5,31 @@
  */
 
 #include "lu.h"
+#include <iostream>
 #include <cstring>
+
+static const double x_mat_test[] = {
+     0.470442000675409, -0.291482508170914, -0.44183986349643 ,
+    -0.176333746005435,  0.007410393215614, -0.739195206041762,
+     0.481736547564898,  0.805743972141035, -0.468344563609981
+};
+
+static const double p_mat_test[] = {1., 0., 0., 0., 0., 1., 0., 1., 0.};
+
+static const double l_mat_test[] = {
+     1.               , -0.9392015654684  , -0.619592867457488,
+     0.               ,  1.               ,  0.112559485278225,
+     0.               ,  0.               ,  1.
+};
+
+static const double u_mat_test[] = {
+     0.470442000675409,  0.               ,  0.               ,
+    -0.176333746005435, -0.904808136334974,  0.               ,
+     0.481736547564898, -0.015896843993687,  1.106013841583318
+};
+
+static const int test_size = 3;
+
 
 LU::LU() {
     x_mat = r_mat = l_mat = u_mat = p_mat = 0;
@@ -15,9 +39,9 @@ void LU::make_args(int size) {
     m = n = lda = size;
 
     mat_size = m * n;
-    int r_size = mat_size,
+    int r_size = mat_size;
 
-        mn_min = min(m, n);
+    mn_min = min(m, n);
     l_size = m * mn_min;
     u_size = mn_min * n;
     p_size = m * m;
@@ -87,7 +111,36 @@ void LU::compute() {
     assert(info == 0);
 }
 
-LU::~LU() {
+bool LU::test() {
+    clean_args();
+    make_args(test_size);
+    memcpy(x_mat, x_mat_test, mat_size * sizeof(*x_mat));
+    copy_args();
+    compute();
+
+    return mat_equal(p_mat, p_mat_test, mat_size)
+        && mat_equal(l_mat, l_mat_test, mat_size)
+        && mat_equal(u_mat, u_mat_test, mat_size);
+}
+
+void LU::print_args() {
+    std::cout << "LU decomposition P*L*U of " << m << "*" << n <<
+        " matrix A." << std::endl;
+    std::cout << "A =" << std::endl;
+    print_mat('c', x_mat, m, n);
+}
+
+void LU::print_result() {
+    std::cout << "P =" << std::endl;
+    print_mat('c', p_mat, m, m);
+    std::cout << "L =" << std::endl;
+    print_mat('c', l_mat, m, mn_min);
+    std::cout << "U =" << std::endl;
+    print_mat('c', u_mat, mn_min, n);
+}
+
+
+void LU::clean_args() {
     if (l_mat)
         mkl_free(l_mat);
     if (u_mat)
@@ -101,4 +154,8 @@ LU::~LU() {
         mkl_free(ipiv);
     if (x_mat)
         mkl_free(x_mat);
+}
+
+LU::~LU() {
+    clean_args();
 }

--- a/numpy/linalg/lu.h
+++ b/numpy/linalg/lu.h
@@ -12,6 +12,10 @@ class LU : public Bench {
     ~LU();
     void make_args(int size);
     void copy_args();
+    void clean_args();
+    bool test();
+    void print_args();
+    void print_result();
     void compute();
 
   private:

--- a/numpy/linalg/qr.cc
+++ b/numpy/linalg/qr.cc
@@ -5,7 +5,32 @@
  */
 
 #include "qr.h"
+#include <iostream>
 #include <cstring>
+
+static const double x_mat_test[] = {
+     0.470442000675409, -0.291482508170914, -0.44183986349643 ,
+    -0.176333746005435,  0.007410393215614, -0.739195206041762,
+     0.481736547564898,  0.805743972141035, -0.468344563609981
+};
+
+static const double q_mat_test[] = {
+    -0.708166783705387, -0.247310653062924, -0.374882547416749,
+    -0.341008805034221, -0.679169383462016, -0.931467229669989,
+    -0.280586627216089, -0.252573245441508,  0.97883501187842
+};
+
+static const double tau_vec_test[] = {
+    1.664309611097381, 1.070875234925678, 0.
+};
+
+static const double r_mat_test[] = {
+    -0.708166783705387,  0.               ,  0.               ,
+    -0.341008805034221, -0.679169383462016,  0.               ,
+    -0.280586627216089, -0.252573245441508,  0.97883501187842
+};
+
+static const int test_size = 3;
 
 QR::QR() {
     x_mat = x_mat_init = r_mat = tau_vec = 0;
@@ -45,7 +70,35 @@ void QR::compute() {
     }
 }
 
-QR::~QR() {
+bool QR::test() {
+    clean_args();
+    make_args(test_size);
+    memcpy(x_mat_init, x_mat_test, mat_size * sizeof(*x_mat));
+    copy_args();
+    compute();
+
+    return mat_equal(x_mat, q_mat_test, mat_size)
+        && mat_equal(tau_vec, tau_vec_test, n)
+        && mat_equal(r_mat, r_mat_test, mat_size);
+}
+
+void QR::print_args() {
+    std::cout << "QR decomposition of " << n << "*" << n <<
+        " matrix A." << std::endl;
+    std::cout << "A =" << std::endl;
+    print_mat('c', x_mat_init, n, n);
+}
+
+void QR::print_result() {
+    std::cout << "LAPACK Q =" << std::endl;
+    print_mat('c', x_mat, n, n);
+    std::cout << "LAPACK tau =" << std::endl;
+    print_mat('c', tau_vec, 1, n);
+    std::cout << "R =" << std::endl;
+    print_mat('c', r_mat, n, n);
+}
+
+void QR::clean_args() {
     if (x_mat)
         mkl_free(x_mat);
     if (x_mat_init)
@@ -54,4 +107,8 @@ QR::~QR() {
         mkl_free(r_mat);
     if (tau_vec)
         mkl_free(tau_vec);
+}
+
+QR::~QR() {
+    clean_args();
 }

--- a/numpy/linalg/qr.h
+++ b/numpy/linalg/qr.h
@@ -12,6 +12,10 @@ class QR : public Bench {
     ~QR();
     void make_args(int size);
     void copy_args();
+    void clean_args();
+    bool test();
+    void print_args();
+    void print_result();
     void compute();
 
   private:

--- a/numpy/linalg/svd.cc
+++ b/numpy/linalg/svd.cc
@@ -5,7 +5,32 @@
  */
 
 #include "svd.h"
+#include <iostream>
 #include <cstring>
+
+static const double x_mat_test[] = {
+     0.470442000675409, -0.291482508170914, -0.44183986349643 ,
+    -0.176333746005435,  0.007410393215614, -0.739195206041762,
+     0.481736547564898,  0.805743972141035, -0.468344563609981
+};
+
+static const double u_mat_test[] = {
+     0.42804756004831 ,  0.513259690621653, -0.743868117558249,
+     0.120044160590577,  0.783501687548245,  0.609683938706898,
+     0.895748115177918, -0.350270746126503,  0.273762156923104
+};
+
+static const double s_vec_test[] = {
+     1.144861136346515, 0.758161081776811, 0.542386469976381
+};
+
+static const double vt_mat_test[] = {
+     0.332298742625904, -0.582047668795011,  0.742157703523676,
+     0.417682073085115, -0.614694207903402, -0.669098435653028,
+     0.845647226373128,  0.532326537024318,  0.038848764550932
+};
+
+static const int test_size = 3;
 
 SVD::SVD() {
     a_mat = r_mat = u_mat = vt_mat = s_vec = 0;
@@ -39,7 +64,35 @@ void SVD::compute() {
     assert(info == 0);
 }
 
-SVD::~SVD() {
+bool SVD::test() {
+    clean_args();
+    make_args(test_size);
+    memcpy(a_mat, x_mat_test, mat_size * sizeof(*a_mat));
+    copy_args();
+    compute();
+
+    return mat_equal(u_mat, u_mat_test, mat_size)
+        && mat_equal(s_vec, s_vec_test, n)
+        && mat_equal(vt_mat, vt_mat_test, mat_size);
+}
+
+void SVD::print_args() {
+    std::cout << "Singular value decomposition of " << n << "*" << n <<
+        " matrix A." << std::endl;
+    std::cout << "A =" << std::endl;
+    print_mat('c', a_mat, n, n);
+}
+
+void SVD::print_result() {
+    std::cout << "U = " << std::endl;
+    print_mat('c', u_mat, n, n);
+    std::cout << "Singular values = " << std::endl;
+    print_mat('c', s_vec, 1, n);
+    std::cout << "V* = " << std::endl;
+    print_mat('c', vt_mat, n, n);
+}
+
+void SVD::clean_args() {
     if (a_mat)
         mkl_free(a_mat);
     if (u_mat)
@@ -48,4 +101,8 @@ SVD::~SVD() {
         mkl_free(vt_mat);
     if (s_vec)
         mkl_free(s_vec);
+}
+
+SVD::~SVD() {
+    clean_args();
 }

--- a/numpy/linalg/svd.h
+++ b/numpy/linalg/svd.h
@@ -12,6 +12,10 @@ class SVD : public Bench {
     ~SVD();
     void make_args(int size);
     void copy_args();
+    void clean_args();
+    bool test();
+    void print_args();
+    void print_result();
     void compute();
 
   private:


### PR DESCRIPTION
- Add a `--verbose` mode to print out inputs and outputs to benchmarks
- Add a `--test` mode to test against known input/output pairs.
- Switch to `std::complex`
- Fix some benchmarks which were giving the wrong result
- Miscellaneous: Use libraries (MKL/LAPACK/BLAS) from `$CONDA_PREFIX` if available.