### PR TITLE
Align umath native bench with both Numba and Numpy versions

### DIFF
--- a/numpy/linalg/Makefile
+++ b/numpy/linalg/Makefile
@@ -4,7 +4,7 @@
 
 CXX = icc
 CXXFLAGS = -O3 -g -xCORE-AVX2 -axCOMMON-AVX512 -qopenmp \
-		   -qopt-report=5 -qopt-report-phase=openmp,par,vec
+	   -qopt-report=5 -qopt-report-phase=openmp,par,vec
 LDFLAGS = -lmkl_rt -qopenmp
 
 TARGET = linalg

--- a/numpy/random/Makefile
+++ b/numpy/random/Makefile
@@ -7,8 +7,8 @@ SOURCES = $(addsuffix .c,$(BENCHMARKS))
 CC = icc
 CLANG_FORMAT = clang-format
 CFLAGS += -m64 -fPIC -fomit-frame-pointer -xSSE4.2 -axCORE-AVX2,CORE-AVX512 \
-		  -O3 -fp-model fast=2 -fimf-precision=high -prec-sqrt -prec-div \
-		  -fprotect-parens
+	  -O3 -fp-model fast=2 -fimf-precision=high -prec-sqrt -prec-div \
+	  -fprotect-parens
 LDFLAGS += -lmkl_rt
 
 run: $(BENCHMARKS)

--- a/numpy/umath/Makefile
+++ b/numpy/umath/Makefile
@@ -4,7 +4,7 @@
 
 CC = icc
 CFLAGS = -qopenmp -xCORE-AVX2 -axCOMMON-AVX512 -O3 \
-		 -g -lmkl_rt
+		 -g -lmkl_rt -Wall -pedantic
 
 ifneq ($(CONDA_PREFIX),)
 		CFLAGS += -I$(CONDA_PREFIX)/include

--- a/numpy/umath/Makefile
+++ b/numpy/umath/Makefile
@@ -6,12 +6,15 @@ CC = icc
 CFLAGS = -qopenmp -xCORE-AVX2 -axCOMMON-AVX512 -O3 \
 		 -g -lmkl_rt
 
+ifneq ($(CONDA_PREFIX),)
+		CFLAGS += -I$(CONDA_PREFIX)/include
+endif
+
 PYTHON ?= python
 
-ACC ?= la
+ACC ?= ha
 ifeq ($(ACC), ha)
 	CFLAGS += -fimf-precision=high -D_VML_ACCURACY_HA_
-	CFLAGS += -fp-model precise
 endif
 ifeq ($(ACC), la)
 	CFLAGS += -fimf-precision=medium -D_VML_ACCURACY_LA_

--- a/numpy/umath/Makefile
+++ b/numpy/umath/Makefile
@@ -4,7 +4,7 @@
 
 CC = icc
 CFLAGS = -qopenmp -xCORE-AVX2 -axCOMMON-AVX512 -O3 \
-		 -g -lmkl_rt -Wall -pedantic
+	 -g -lmkl_rt -Wall -pedantic
 
 ifneq ($(CONDA_PREFIX),)
 		CFLAGS += -I$(CONDA_PREFIX)/include

--- a/numpy/umath/umath_bench.c.src
+++ b/numpy/umath/umath_bench.c.src
@@ -4,14 +4,15 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
 #include "mkl.h"
-#include <assert.h>
 #include "rdtsc.h"
+#include <assert.h>
 #include <complex.h>
+#include <getopt.h>
+#include <math.h>
 #include <mathimf.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #define SEED 77777
 
@@ -40,11 +41,8 @@ static void _print_mkl_version() {
     char buf[198];
 
     mkl_get_version_string(buf, len);
-    printf("\nMKL Version: %s\n", buf);
+    puts(buf);
 }
-
-#define EXPERIMS_N 3
-#define REPS_N 100
 
 typedef struct experiment_t {
     long array_size;
@@ -69,27 +67,79 @@ static void populate_experiment_sizes(experiment_t *list, int s0, size_t n) {
     return;
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char *argv[]) {
     VSLStreamStatePtr stream;
     double *x1, *x2, *y, CPE, CPE_min;
     double c = 4321.43;
     int err = 0;
     size_t j, i, k, l;
     const double d_zero = 0.0, d_one = 1.0;
-    experiment_t experims[EXPERIMS_N];
     rdtsc_type t0, t1;
-    long int arraySize = argc > 1 ? atol(argv[1]) : 2500000;
-    long int n = arraySize;
-    char *prefix = argc > 2 ? argv[2] : "@";
 
-    populate_experiment_sizes(experims, 2, EXPERIMS_N);
+    /* Default options */
+    long int n = 2500000;
+    int outer_loops = 3;
+    int inner_loops = 5000;
+    int verbose = 0;
+    char *prefix = "Native-C";
+
+    /* Command line option parsing */
+    static const struct option longopts[] = {
+        {"size", required_argument, NULL, 'n'},
+        {"inner-loops", required_argument, NULL, 'r'},
+        {"outer-loops", required_argument, NULL, 's'},
+        {"prefix", required_argument, NULL, 'p'},
+        {"verbose", no_argument, NULL, 'v'},
+        {"help", no_argument, NULL, 'h'},
+        {0, 0, 0, 0}};
+
+    int opt;
+    int optind = 0;
+    while ((opt = getopt_long(argc, argv, "vhn:r:s:p:", longopts,
+                              &optind)) != -1) {
+        switch (opt) {
+        case 'n':
+            n = atol(optarg);
+            break;
+        case 'r':
+            inner_loops = atol(optarg);
+            break;
+        case 's':
+            outer_loops = atol(optarg);
+            break;
+        case 'p':
+            prefix = optarg;
+            break;
+        case 'h':
+            printf("usage: %s [-h] [-v] [-n SIZE] [-r INNER_LOOPS] "
+                   "[-s OUTER_LOOPS]\n", argv[0]);
+            return EXIT_SUCCESS;
+        case 'v':
+            verbose = 1;
+            break;
+        case '?':
+            break;
+        default:
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (verbose) {
+        printf("@ MKL: ");
+        _print_mkl_version();
+        printf("@ n = %d; outer_loops = %d; inner_loops = %d\n",
+               n, outer_loops, inner_loops);
+    }
+
+    experiment_t *experims = (experiment_t *)
+            malloc(outer_loops * sizeof(*experims));
+
+    populate_experiment_sizes(experims, 2, outer_loops);
 
     err = vslNewStream(&stream, VSL_BRNG_SFMT19937, SEED);
     assert(err == VSL_STATUS_OK);
 
     {
-        long int n = arraySize;
-
         x1 = (double *) mkl_malloc(n * sizeof(double), 64);
         x2 = (double *) mkl_malloc(n * sizeof(double), 64);
         y = (double *) mkl_malloc(n * sizeof(double), 64);
@@ -102,11 +152,11 @@ int main(int argc, char **argv) {
         assert(err == VSL_STATUS_OK);
     }
 
-#define TIME_CPE_HERE TIME_CPE(REPS_N, n, j, t0, t1, CPE, CPE_min)
+#define TIME_CPE_HERE TIME_CPE(inner_loops, n, j, t0, t1, CPE, CPE_min)
 #define PRINT_LINE_HERE(impl, func) PRINT_LINE(impl, func, prefix, n, CPE_min)
 
     int experiments;
-    for (experiments = 0; experiments < EXPERIMS_N; experiments++) {
+    for (experiments = 0; experiments < outer_loops; experiments++) {
 
 /**begin repeat
  *  #func = +, -, *, /#
@@ -198,6 +248,8 @@ int main(int argc, char **argv) {
         mkl_free(x2);
     if (y)
         mkl_free(y);
+    if (experims)
+        free(experims);
 
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);

--- a/numpy/umath/umath_bench.c.src
+++ b/numpy/umath/umath_bench.c.src
@@ -36,6 +36,11 @@
 #define PRINT_LINE(impl, func, prefix, n, cpe) \
     printf("%s, " impl ", " func ", %ld, %.4g\n", prefix, n, cpe);
 
+#define DEFAULT_INNER_LOOPS 5000
+#define DEFAULT_OUTER_LOOPS 3
+#define DEFAULT_SIZE 2500000
+#define DEFAULT_PREFIX "Native-C"
+
 static void _print_mkl_version() {
     int len = 198;
     char buf[198];
@@ -67,6 +72,11 @@ static void populate_experiment_sizes(experiment_t *list, int s0, size_t n) {
     return;
 }
 
+void print_usage(const char *exe) {
+    printf("usage: %s [-h] [-v] [--header] [-n SIZE] [-r INNER_LOOPS] "
+           "[-s OUTER_LOOPS]\n", exe);
+}
+
 int main(int argc, char *argv[]) {
     VSLStreamStatePtr stream;
     double *x1, *x2, *y, CPE, CPE_min;
@@ -77,11 +87,12 @@ int main(int argc, char *argv[]) {
     rdtsc_type t0, t1;
 
     /* Default options */
-    long int n = 2500000;
-    int outer_loops = 3;
-    int inner_loops = 5000;
+    long int n = DEFAULT_SIZE;
+    int outer_loops = DEFAULT_OUTER_LOOPS;
+    int inner_loops = DEFAULT_INNER_LOOPS;
     int verbose = 0;
-    char *prefix = "Native-C";
+    int header = 0;
+    char *prefix = DEFAULT_PREFIX;
 
     /* Command line option parsing */
     static const struct option longopts[] = {
@@ -90,6 +101,7 @@ int main(int argc, char *argv[]) {
         {"outer-loops", required_argument, NULL, 's'},
         {"prefix", required_argument, NULL, 'p'},
         {"verbose", no_argument, NULL, 'v'},
+        {"header", no_argument, NULL, 'w'},
         {"help", no_argument, NULL, 'h'},
         {0, 0, 0, 0}};
 
@@ -111,15 +123,36 @@ int main(int argc, char *argv[]) {
             prefix = optarg;
             break;
         case 'h':
-            printf("usage: %s [-h] [-v] [-n SIZE] [-r INNER_LOOPS] "
-                   "[-s OUTER_LOOPS]\n", argv[0]);
+            print_usage(argv[0]);
+            printf("\nBenchmarks for VML/SVML arithmetic and transcendentals\n"
+                   "\noptional arguments:\n"
+                   "  -h, --help\t\tshow this help message and exit\n"
+                   "  -v, --verbose\t\tprint extra messages\n"
+                   "  --header\t\tprint CSV header\n"
+                   "  -n SIZE, --size SIZE\tproblem size "
+                   "(default %d)\n"
+                   "  -s OUTER_LOOPS, --outer-loops OUTER_LOOPS\n"
+                   "\t\t\tnumber of outer iterations to run, no aggregation "
+                   "(default %d)\n"
+                   "  -r INNER_LOOPS, --inner-loops INNER_LOOPS\n"
+                   "\t\t\tnumber of inner iterations to run, taking the min "
+                   "(default %d)\n"
+                   "  -p PREFIX, --prefix PREFIX\n"
+                   "\t\t\tbookkeeping string "
+                   "to report with data (default '%s')"
+                   "\n",
+                   DEFAULT_SIZE, DEFAULT_OUTER_LOOPS, DEFAULT_INNER_LOOPS,
+                   DEFAULT_PREFIX);
             return EXIT_SUCCESS;
         case 'v':
             verbose = 1;
             break;
-        case '?':
+        case 'w':
+            header = 1;
             break;
+        case '?':
         default:
+            print_usage(argv[0]);
             return EXIT_FAILURE;
         }
     }
@@ -127,8 +160,12 @@ int main(int argc, char *argv[]) {
     if (verbose) {
         printf("@ MKL: ");
         _print_mkl_version();
-        printf("@ n = %d; outer_loops = %d; inner_loops = %d\n",
+        printf("@ n = %ld; outer_loops = %d; inner_loops = %d\n",
                n, outer_loops, inner_loops);
+    }
+
+    if (header) {
+        puts("Prefix, Implementation, Function, Size, CPE");
     }
 
     experiment_t *experims = (experiment_t *)

--- a/numpy/umath/umath_bench.c.src
+++ b/numpy/umath/umath_bench.c.src
@@ -70,43 +70,43 @@ static void populate_experiment_sizes(experiment_t *list, int s0, size_t n) {
 }
 
 int main(int argc, char **argv) {
-  VSLStreamStatePtr stream;
-  double *x1, *x2, *y, CPE, CPE_min;
-  double c = 4321.43;
-  int err = 0;
-  size_t j, i, k, l;
-  const double d_zero = 0.0, d_one = 1.0;
-  experiment_t experims[EXPERIMS_N];
-  rdtsc_type t0, t1;
-  long int arraySize = argc>1?atol(argv[1]):2500000;
+    VSLStreamStatePtr stream;
+    double *x1, *x2, *y, CPE, CPE_min;
+    double c = 4321.43;
+    int err = 0;
+    size_t j, i, k, l;
+    const double d_zero = 0.0, d_one = 1.0;
+    experiment_t experims[EXPERIMS_N];
+    rdtsc_type t0, t1;
+    long int arraySize = argc>1?atol(argv[1]):2500000;
     long int n = arraySize;
-  char *prefix = argc>2?argv[2]:"@";
+    char *prefix = argc>2?argv[2]:"@";
 
-  populate_experiment_sizes(experims, 2, EXPERIMS_N);
+    populate_experiment_sizes(experims, 2, EXPERIMS_N);
 
-  err = vslNewStream(&stream, VSL_BRNG_SFMT19937, SEED);
-  assert(err == VSL_STATUS_OK);
-
-  {
-    long int n = arraySize;
-
-    x1 = (double *) mkl_malloc( n*sizeof(double), 64);
-    x2 = (double *) mkl_malloc( n*sizeof(double), 64);
-    y  = (double *) mkl_malloc( n*sizeof(double), 64);
-
-    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, stream,
-                           n, x1, d_zero, d_one);
+    err = vslNewStream(&stream, VSL_BRNG_SFMT19937, SEED);
     assert(err == VSL_STATUS_OK);
-    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, stream,
-                           n, x2, d_zero, d_one);
-    assert(err == VSL_STATUS_OK);
-  }
+
+    {
+        long int n = arraySize;
+
+        x1 = (double *) mkl_malloc( n*sizeof(double), 64);
+        x2 = (double *) mkl_malloc( n*sizeof(double), 64);
+        y  = (double *) mkl_malloc( n*sizeof(double), 64);
+
+        err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE,
+                               stream, n, x1, d_zero, d_one);
+        assert(err == VSL_STATUS_OK);
+        err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE,
+                               stream, n, x2, d_zero, d_one);
+        assert(err == VSL_STATUS_OK);
+    }
 
 #define TIME_CPE_HERE TIME_CPE(REPS_N, n, j, t0, t1, CPE, CPE_min)
 #define PRINT_LINE_HERE(impl, func) PRINT_LINE(impl, func, prefix, n, CPE_min)
 
     int experiments;
-    for(experiments = 0; experiments<EXPERIMS_N; experiments++) {
+    for (experiments = 0; experiments < EXPERIMS_N; experiments++) {
 
 /**begin repeat
  *  #func = +, -, *, /#
@@ -162,7 +162,7 @@ int main(int argc, char **argv) {
                 y[l] = x1[l] / c;
             }
         }
-        printf("%s, SVML, array/scalar, %ld, %.4g\n", prefix, n, CPE_min);
+        PRINT_LINE_HERE("SVML", "array/scalar");
 
 /**begin repeat
  *  #func = log10, exp, erf#
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
         TIME_CPE_HERE {
             vd@vml@(n, x1, y);
         }
-        printf("%s, VML, @func@, %ld, %.4g\n", prefix, n, CPE_min);
+        PRINT_LINE_HERE("VML", "@func@");
 
         TIME_CPE_HERE {
 #pragma omp parallel for
@@ -180,14 +180,14 @@ int main(int argc, char **argv) {
                 y[l] = @func@(x1[l]);
             }
         }
-        printf("%s, SVML, @func@, %ld, %.4g\n", prefix, n, CPE_min);
+        PRINT_LINE_HERE("SVML", "@func@");
 
 /**end repeat**/
 
         TIME_CPE_HERE {
             vdInvSqrt(n, x1, y);
         }
-        printf("%s, VML, invsqrt, %ld, %.4g\n", prefix, n, CPE_min);
+        PRINT_LINE_HERE("VML", "invsqrt");
 
         TIME_CPE_HERE {
 #pragma omp parallel for
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
                 y[l] = 1 / sqrt(x1[l]);
             }
         }
-        printf("%s, SVML, invsqrt, %ld, %.4g\n", prefix, n, CPE_min);
+        PRINT_LINE_HERE("SVML", "invsqrt");
     }
 
     if (x1)

--- a/numpy/umath/umath_bench.c.src
+++ b/numpy/umath/umath_bench.c.src
@@ -15,20 +15,40 @@
 
 #define SEED 77777
 
-static void _print_mkl_version() {
-  int len = 198;
-  char buf[198];
+/*
+ * Inner timing loop, emitting CPE. Note that this is just a glorified
+ * for-loop!
+ *
+ * reps - number of repetitions
+ * n - problem size
+ * j - temporary iteration variable
+ * t0, t1 - temporary timing variables (rdtsc_type)
+ * cpe - cpe variable to set
+ * cpe_min - cpe_min variable to set
+ */
+#define TIME_CPE(reps, n, j, t0, t1, cpe, cpe_min) \
+    cpe_min = 100000000.0; \
+    for (j = 0; t0 = timer_rdtsc(), j < reps; t1 = timer_rdtsc(), \
+         cpe = ((double) (t1 - t0) / n), \
+         cpe_min = cpe < cpe_min ? cpe : cpe_min, j++)
 
-  mkl_get_version_string(buf, len);
-  printf("\nMKL Version: %s\n", buf);
+#define PRINT_LINE(impl, func, prefix, n, cpe) \
+    printf("%s, " impl ", " func ", %ld, %.4g\n", prefix, n, cpe);
+
+static void _print_mkl_version() {
+    int len = 198;
+    char buf[198];
+
+    mkl_get_version_string(buf, len);
+    printf("\nMKL Version: %s\n", buf);
 }
 
 #define EXPERIMS_N 3
-#define REPS_N 5000
+#define REPS_N 100
 
 typedef struct experiment_t {
-  long array_size;
-  long repetitions;
+    long array_size;
+    long repetitions;
 } experiment_t;
 
 static void populate_experiment_sizes(experiment_t *list, int s0, size_t n) {
@@ -59,6 +79,7 @@ int main(int argc, char **argv) {
   experiment_t experims[EXPERIMS_N];
   rdtsc_type t0, t1;
   long int arraySize = argc>1?atol(argv[1]):2500000;
+    long int n = arraySize;
   char *prefix = argc>2?argv[2]:"@";
 
   populate_experiment_sizes(experims, 2, EXPERIMS_N);
@@ -73,53 +94,41 @@ int main(int argc, char **argv) {
     x2 = (double *) mkl_malloc( n*sizeof(double), 64);
     y  = (double *) mkl_malloc( n*sizeof(double), 64);
 
-    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, stream, n, x1, d_zero, d_one);
+    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, stream,
+                           n, x1, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
-    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, stream, n, x2, d_zero, d_one);
+    err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE, stream,
+                           n, x2, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
   }
 
-  for(int experiments = 0; experiments<EXPERIMS_N; experiments++) {
+#define TIME_CPE_HERE TIME_CPE(REPS_N, n, j, t0, t1, CPE, CPE_min)
+#define PRINT_LINE_HERE(impl, func) PRINT_LINE(impl, func, prefix, n, CPE_min)
+
+    int experiments;
+    for(experiments = 0; experiments<EXPERIMS_N; experiments++) {
 
 /**begin repeat
- *  #BEGIN =
-    size_t reps = REPS_N;
-    long int n = arraySize;
-    CPE_min = 100000000.0;
-    for (j=0; j < reps; j++) {
-      t0 = timer_rdtsc();
-    #
- *  #END = 
-      t1 = timer_rdtsc();
-      CPE = ((double)(t1 - t0)/n);
-      CPE_min = CPE < CPE_min ? CPE : CPE_min;
-    }
- #
- */
-
-/**begin repeat1
  *  #func = +, -, *, /#
  *  #vml = Add, Sub, Mul, Div#
  */
-  { @BEGIN@
-      vd@vml@(n, x1, x2, y);
-    @END@
-    printf("%s, VML, array@func@array, %ld, %.4g\n", prefix, n, CPE_min);
-  }
+        TIME_CPE_HERE {
+            vd@vml@(n, x1, x2, y);
+        }
+        PRINT_LINE_HERE("VML", "array@func@array");
 
-  { @BEGIN@
-      #pragma omp parallel for
-      for(l=0; l < n; l++) {
-        y[l] = x1[l] @func@ x2[l];
-      }
-    @END@
-    printf("%s, SVML, array@func@array, %ld, %.4g\n", prefix, n, CPE_min);
-  }
+        TIME_CPE_HERE {
+#pragma omp parallel for
+            for (l = 0; l < n; l++) {
+                y[l] = x1[l] @func@ x2[l];
+            }
+        }
+        PRINT_LINE_HERE("SVML", "array@func@array");
 
 
-/**end repeat1**/
+/**end repeat**/
 
-/**begin repeat1
+/**begin repeat
  *  #func=   +,   -,   *#
  *  #in1 =   n,   n,   n#
  *  #in2 =  x1,  x1,  x1#
@@ -131,63 +140,71 @@ int main(int argc, char **argv) {
  *  #in8 =   y,   y,   y#
  */
 
-  { @BEGIN@
-      vdLinearFrac(@in1@, @in2@, @in3@, @in4@, @in5@, @in6@, @in7@, @in8@);
-    @END@
-    printf("%s, VML, array@func@scalar, %ld, %.4g\n", prefix, n, CPE_min);
-  }
+        TIME_CPE_HERE {
+            vdLinearFrac(@in1@, @in2@, @in3@, @in4@, @in5@, @in6@, @in7@,
+                         @in8@);
+        }
+        PRINT_LINE_HERE("VML", "array@func@scalar");
 
-  { @BEGIN@
-      #pragma omp parallel for
-      for(l=0; l < n; l++) {
-        y[l] = x1[l] @func@ c;
-      }
-    @END@
-    printf("%s, SVML, array@func@scalar, %ld, %.4g\n", prefix, n, CPE_min);
-  }
+        TIME_CPE_HERE {
+#pragma omp parallel for
+            for(l=0; l < n; l++) {
+                y[l] = x1[l] @func@ c;
+            }
+        }
+        PRINT_LINE_HERE("SVML", "array@func@scalar");
 
-/**end repeat1**/
+/**end repeat**/
 
-  { @BEGIN@
-      #pragma omp parallel for
-      for(l=0; l < n; l++) {
-        y[l] = x1[l] / c;
-      }
-    @END@
-    printf("%s, SVML, array/scalar, %ld, %.4g\n", prefix, n, CPE_min);
-  }
+        TIME_CPE_HERE {
+#pragma omp parallel for
+            for(l=0; l < n; l++) {
+                y[l] = x1[l] / c;
+            }
+        }
+        printf("%s, SVML, array/scalar, %ld, %.4g\n", prefix, n, CPE_min);
 
-/**begin repeat1
- *  #func = log10, exp, erf, invsqrt#
- *  #vml =  Log10, Exp, Erf, InvSqrt#
+/**begin repeat
+ *  #func = log10, exp, erf#
+ *  #vml =  Log10, Exp, Erf#
  */
 
-  { @BEGIN@
-      vd@vml@(n, x1, y);
-    @END@
-    printf("%s, VML, @func@, %ld, %.4g\n", prefix, n, CPE_min);
-  }
+        TIME_CPE_HERE {
+            vd@vml@(n, x1, y);
+        }
+        printf("%s, VML, @func@, %ld, %.4g\n", prefix, n, CPE_min);
 
-  { @BEGIN@
-      #pragma omp parallel for
-      for(l=0; l < n; l++) {
-        y[l] = @func@(x1[l]);
-      }
-    @END@
-    printf("%s, SVML, @func@, %ld, %.4g\n", prefix, n, CPE_min);
-  }
+        TIME_CPE_HERE {
+#pragma omp parallel for
+            for(l=0; l < n; l++) {
+                y[l] = @func@(x1[l]);
+            }
+        }
+        printf("%s, SVML, @func@, %ld, %.4g\n", prefix, n, CPE_min);
 
-/**end repeat1**/
 /**end repeat**/
- }
 
-  if (x1)
-    mkl_free(x1);
-  if (x2)
-    mkl_free(x2);
-  if (y)
-    mkl_free(y);
+        TIME_CPE_HERE {
+            vdInvSqrt(n, x1, y);
+        }
+        printf("%s, VML, invsqrt, %ld, %.4g\n", prefix, n, CPE_min);
 
-  err = vslDeleteStream(&stream);
-  assert(err == VSL_STATUS_OK);
+        TIME_CPE_HERE {
+#pragma omp parallel for
+            for(l=0; l < n; l++) {
+                y[l] = 1 / sqrt(x1[l]);
+            }
+        }
+        printf("%s, SVML, invsqrt, %ld, %.4g\n", prefix, n, CPE_min);
+    }
+
+    if (x1)
+        mkl_free(x1);
+    if (x2)
+        mkl_free(x2);
+    if (y)
+        mkl_free(y);
+
+    err = vslDeleteStream(&stream);
+    assert(err == VSL_STATUS_OK);
 }

--- a/numpy/umath/umath_bench.c.src
+++ b/numpy/umath/umath_bench.c.src
@@ -52,21 +52,21 @@ typedef struct experiment_t {
 } experiment_t;
 
 static void populate_experiment_sizes(experiment_t *list, int s0, size_t n) {
-  int i;
-  long s, r;
-  long r_max = (1 << 16);
+    int i;
+    long s, r;
+    long r_max = (1 << 16);
 
-  s = (1 << s0);
-  r = (2 << n);
+    s = (1 << s0);
+    r = (2 << n);
 
-  for(i=0; i < n; i++) {
-    list[i].array_size = s;
-    list[i].repetitions = (r > r_max) ? r_max : r;
-    s <<= 1;
-    r >>= 1;
-  }
+    for (i = 0; i < n; i++) {
+        list[i].array_size = s;
+        list[i].repetitions = (r > r_max) ? r_max : r;
+        s <<= 1;
+        r >>= 1;
+    }
 
-  return;
+    return;
 }
 
 int main(int argc, char **argv) {
@@ -78,9 +78,9 @@ int main(int argc, char **argv) {
     const double d_zero = 0.0, d_one = 1.0;
     experiment_t experims[EXPERIMS_N];
     rdtsc_type t0, t1;
-    long int arraySize = argc>1?atol(argv[1]):2500000;
+    long int arraySize = argc > 1 ? atol(argv[1]) : 2500000;
     long int n = arraySize;
-    char *prefix = argc>2?argv[2]:"@";
+    char *prefix = argc > 2 ? argv[2] : "@";
 
     populate_experiment_sizes(experims, 2, EXPERIMS_N);
 
@@ -90,9 +90,9 @@ int main(int argc, char **argv) {
     {
         long int n = arraySize;
 
-        x1 = (double *) mkl_malloc( n*sizeof(double), 64);
-        x2 = (double *) mkl_malloc( n*sizeof(double), 64);
-        y  = (double *) mkl_malloc( n*sizeof(double), 64);
+        x1 = (double *) mkl_malloc(n * sizeof(double), 64);
+        x2 = (double *) mkl_malloc(n * sizeof(double), 64);
+        y = (double *) mkl_malloc(n * sizeof(double), 64);
 
         err = vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF_ACCURATE,
                                stream, n, x1, d_zero, d_one);
@@ -124,8 +124,6 @@ int main(int argc, char **argv) {
             }
         }
         PRINT_LINE_HERE("SVML", "array@func@array");
-
-
 /**end repeat**/
 
 /**begin repeat
@@ -139,7 +137,6 @@ int main(int argc, char **argv) {
  *  #in7 = 1.0, 1.0, 1.0#
  *  #in8 =   y,   y,   y#
  */
-
         TIME_CPE_HERE {
             vdLinearFrac(@in1@, @in2@, @in3@, @in4@, @in5@, @in6@, @in7@,
                          @in8@);
@@ -148,17 +145,16 @@ int main(int argc, char **argv) {
 
         TIME_CPE_HERE {
 #pragma omp parallel for
-            for(l=0; l < n; l++) {
+            for (l = 0; l < n; l++) {
                 y[l] = x1[l] @func@ c;
             }
         }
         PRINT_LINE_HERE("SVML", "array@func@scalar");
-
 /**end repeat**/
 
         TIME_CPE_HERE {
 #pragma omp parallel for
-            for(l=0; l < n; l++) {
+            for (l = 0; l < n; l++) {
                 y[l] = x1[l] / c;
             }
         }
@@ -168,7 +164,6 @@ int main(int argc, char **argv) {
  *  #func = log10, exp, erf#
  *  #vml =  Log10, Exp, Erf#
  */
-
         TIME_CPE_HERE {
             vd@vml@(n, x1, y);
         }
@@ -176,12 +171,11 @@ int main(int argc, char **argv) {
 
         TIME_CPE_HERE {
 #pragma omp parallel for
-            for(l=0; l < n; l++) {
+            for (l = 0; l < n; l++) {
                 y[l] = @func@(x1[l]);
             }
         }
         PRINT_LINE_HERE("SVML", "@func@");
-
 /**end repeat**/
 
         TIME_CPE_HERE {
@@ -191,7 +185,7 @@ int main(int argc, char **argv) {
 
         TIME_CPE_HERE {
 #pragma omp parallel for
-            for(l=0; l < n; l++) {
+            for (l = 0; l < n; l++) {
                 y[l] = 1 / sqrt(x1[l]);
             }
         }

--- a/numpy/umath/umath_mem_bench.py
+++ b/numpy/umath/umath_mem_bench.py
@@ -9,8 +9,8 @@ import warnings
 import itertools
 import time
 import gc
-import numpy.core.umath as ncu
 import numpy as np
+import numpy.core.umath
 import argparse
 
 try:
@@ -101,7 +101,10 @@ def getUnaryFuncImpl(func, impl):
             return numbaKernel("x", "math.%s(x[i])"%func, "(f8[::1],f8[::1])")
     elif impl == 'numpy':
         try:
-            return getattr(np.core.umath, func, getattr(np, func))
+            ufunc = getattr(np.core.umath, func, None)
+            if not ufunc:
+                ufunc = getattr(np, func)
+            return ufunc
         except:
             if func == "erf":
                 from scipy.special import erf


### PR DESCRIPTION
- Use high accuracy VML/SVML functions in native code
- Drop `-fp-model precise` flag
- Minor cleanup in `umath_bench.c.src`: remove outer layer of numpy templating and replace with preprocessor directives
- Fix python benchmark's logic to look up erf, invsqrt from numpy.core.umath.
- Use 1/sqrt for SVML "invsqrt" to match Numba
- Parse command-line options in umath native benchmarks using getopt_long - use `./<executable> -h` for help.
```
usage: ./umath_ha [-h] [-v] [--header] [-n SIZE] [-r INNER_LOOPS] [-s OUTER_LOOPS]

Benchmarks for VML/SVML arithmetic and transcendentals

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         print extra messages
  --header              print CSV header
  -n SIZE, --size SIZE  problem size (default 2500000)
  -s OUTER_LOOPS, --outer-loops OUTER_LOOPS
                        number of outer iterations to run, no aggregation (default 3)
  -r INNER_LOOPS, --inner-loops INNER_LOOPS
                        number of inner iterations to run, taking the min (default 5000)
  -p PREFIX, --prefix PREFIX
                        bookkeeping string to report with data (default 'Native-C')
```                              