### PR TITLE
Use dgetrf/dgetri for inverse instead of dgesv

### DIFF
--- a/numpy/linalg/Makefile
+++ b/numpy/linalg/Makefile
@@ -4,7 +4,8 @@
 
 CXX = icc
 CXXFLAGS = -O3 -g -xCORE-AVX2 -axCOMMON-AVX512 -qopenmp \
-	   -qopt-report=5 -qopt-report-phase=openmp,par,vec
+	   -qopt-report=5 -qopt-report-phase=openmp,par,vec \
+	   -DNDEBUG
 LDFLAGS = -lmkl_rt -qopenmp
 
 TARGET = linalg
@@ -12,7 +13,7 @@ BENCHES = cholesky det dot eig inv lu qr svd
 SOURCES = $(addsuffix .cc,$(BENCHES)) linalg.cc
 
 ifneq ($(CONDA_PREFIX),)
-	LDFLAGS += -L$(CONDA_PREFIX)/lib
+	LDFLAGS += -L$(CONDA_PREFIX)/lib -Wl,-rpath,$(CONDA_PREFIX)
 	CXXFLAGS += -I$(CONDA_PREFIX)/include
 endif
 

--- a/numpy/linalg/Makefile
+++ b/numpy/linalg/Makefile
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 CXX = icc
-CXXFLAGS = -O3 -g -xCORE-AVX2 -axCOMMON-AVX512 -qopenmp \
+CXXFLAGS = -O3 -g -xCORE-AVX2 -axCOMMON-AVX512 \
 	   -qopt-report=5 -qopt-report-phase=openmp,par,vec
-LDFLAGS = -lmkl_rt -qopenmp
+LDFLAGS = -lmkl_rt
 
 TARGET = linalg
 BENCHES = cholesky det dot eig inv lu qr svd

--- a/numpy/linalg/Makefile
+++ b/numpy/linalg/Makefile
@@ -4,8 +4,7 @@
 
 CXX = icc
 CXXFLAGS = -O3 -g -xCORE-AVX2 -axCOMMON-AVX512 -qopenmp \
-	   -qopt-report=5 -qopt-report-phase=openmp,par,vec \
-	   -DNDEBUG
+	   -qopt-report=5 -qopt-report-phase=openmp,par,vec
 LDFLAGS = -lmkl_rt -qopenmp
 
 TARGET = linalg

--- a/numpy/linalg/bench.h
+++ b/numpy/linalg/bench.h
@@ -135,5 +135,5 @@ class Bench {
     virtual void print_args() = 0;
     virtual void print_result() = 0;
     virtual void compute() = 0;
-    virtual bool test() {return false;};
+    virtual bool test(bool verbose) {return false;};
 };

--- a/numpy/linalg/cholesky.cc
+++ b/numpy/linalg/cholesky.cc
@@ -87,11 +87,10 @@ bool Cholesky::test(bool verbose) {
 
     // try to reconstruct x_mat from its Cholesky decomposition
     static const double alpha = 1., beta = 0.;
-    static const char no_transpose = 'N';
-    static const char transpose = 'T';
+    static const char uplo = 'U';
+    static const char trans = 'T';
     double *c = make_mat(mat_size);
-    dgemm(&transpose, &no_transpose, &n, &n, &n, &alpha, r_mat, &n,
-          r_mat, &n, &beta, c, &n);
+    dsyrk(&uplo, &trans, &n, &n, &alpha, r_mat, &n, &beta, c, &n);
 
     if (verbose) {
         std::cout << "U* * U = (should be equal to A)" << std::endl;

--- a/numpy/linalg/cholesky.cc
+++ b/numpy/linalg/cholesky.cc
@@ -30,8 +30,12 @@ void Cholesky::make_args(int size) {
     for (int i = 0; i < n; i++) {
         r_mat[i * n + i] = 1;
     }
-    cblas_dgemm(CblasColMajor, CblasNoTrans, CblasTrans, n, n, n, 1.0, x_mat, n,
-                x_mat, n, n, r_mat, n);
+
+    static const char uplo = 'U';
+    static const char trans = 'T';
+    static const double alpha = 1.;
+    static const double beta = n;
+    dsyrk(&uplo, &trans, &n, &n, &alpha, x_mat, &n, &beta, r_mat, &n);
 
     // we now have r_mat = x_mat * x_mat' + n * np.eye(n)
     // copy back into x_mat

--- a/numpy/linalg/cholesky.cc
+++ b/numpy/linalg/cholesky.cc
@@ -54,17 +54,23 @@ void Cholesky::make_args(int size) {
 }
 
 void Cholesky::copy_args() {
-    memcpy(r_mat, x_mat, mat_size * sizeof(*x_mat));
+    // copy moved to compute()
 }
 
 void Cholesky::compute() {
+    // perform copy here.
+    static const int one = 1;
+    dcopy(&mat_size, x_mat, &one, r_mat, &one);
+
     // compute cholesky decomposition
     int info;
-    const char uplo = 'U';
+    static const char uplo = 'U';
     dpotrf(&uplo, &n, r_mat, &lda, &info);
     assert(info == 0);
 
     // we only want an upper triangular matrix
+    // in scipy, this is done in *potrf wrapper.
+    // https://github.com/scipy/scipy/blob/maintenance/1.3.x/scipy/linalg/flapack_pos_def.pyf.src#L85
     for (int i = 0; i < n - 1; i++) {
         memset(&r_mat[i * n + i + 1], 0, (n - i - 1) * sizeof(*r_mat));
     }

--- a/numpy/linalg/cholesky.cc
+++ b/numpy/linalg/cholesky.cc
@@ -56,8 +56,10 @@ void Cholesky::compute() {
     // we only want an upper triangular matrix
     // in scipy, this is done in *potrf wrapper.
     // https://github.com/scipy/scipy/blob/maintenance/1.3.x/scipy/linalg/flapack_pos_def.pyf.src#L85
-    for (int i = 0; i < n - 1; i++) {
-        memset(&r_mat[i * n + i + 1], 0, (n - i - 1) * sizeof(*r_mat));
+    for (int i = 0; i < n; i++) {
+        for (int j = i + 1; j < n; j++) {
+            r_mat[i * n + j] = 0.;
+        }
     }
 }
 

--- a/numpy/linalg/cholesky.cc
+++ b/numpy/linalg/cholesky.cc
@@ -8,22 +8,7 @@
 #include <cstring>
 #include <iostream>
 
-static const double x_mat_test[] = {
-    5.551063927745538,  0.034194385271978, -0.276508795460738,
-    0.034194385271978,  4.704686460853461, 0.087572555571367,
-    -0.276508795460738, 0.087572555571367, 6.07658590927362};
-
-static const double r_mat_test[] = {2.356069593145656,
-                                    0.,
-                                    0.,
-                                    0.014513317166631,
-                                    2.16898036516661,
-                                    0.,
-                                    -0.117360198639788,
-                                    0.041160281019929,
-                                    2.461933858639425};
-
-static const int test_size = 3;
+static const int test_size = 5;
 
 Cholesky::Cholesky() {
     x_mat = r_mat = 0;
@@ -76,25 +61,50 @@ void Cholesky::compute() {
     }
 }
 
-bool Cholesky::test() {
+bool Cholesky::test(bool verbose) {
     clean_args();
     make_args(test_size);
-    memcpy(x_mat, x_mat_test, mat_size * sizeof(*x_mat));
     copy_args();
     compute();
 
-    return mat_equal(r_mat, r_mat_test, mat_size);
+    // verify that r_mat is upper triangular
+    for (int i = 0; i < n; i++) {
+        for (int j = i + 1; j < n; j++) {
+            if (r_mat[i * n + j] != 0.) {
+                if (verbose) {
+                    std::cerr << "r_mat is not upper triangular!" << std::endl;
+                }
+                return false;
+            }
+        }
+    }
+
+    // try to reconstruct x_mat from its Cholesky decomposition
+    static const double alpha = 1., beta = 0.;
+    static const char no_transpose = 'N';
+    static const char transpose = 'T';
+    double *c = make_mat(mat_size);
+    dgemm(&transpose, &no_transpose, &n, &n, &n, &alpha, r_mat, &n,
+          r_mat, &n, &beta, c, &n);
+
+    if (verbose) {
+        std::cout << "U* * U = (should be equal to A)" << std::endl;
+        print_mat('c', c, n, n);
+    }
+    bool equal = mat_equal(c, x_mat, mat_size);
+    mkl_free(c);
+    return equal;
 }
 
 void Cholesky::print_args() {
-    std::cout << "Cholesky decomposition, A = LL*, of a "
+    std::cout << "Cholesky decomposition, A = U* * U, of a "
               << "Hermitian positive-definite matrix A." << std::endl;
     std::cout << "A = " << std::endl;
     print_mat('c', x_mat, n, n);
 }
 
 void Cholesky::print_result() {
-    std::cout << "L = " << std::endl;
+    std::cout << "U = " << std::endl;
     print_mat('c', r_mat, n, n);
 }
 

--- a/numpy/linalg/cholesky.h
+++ b/numpy/linalg/cholesky.h
@@ -16,7 +16,7 @@ class Cholesky : public Bench {
     void print_args();
     void print_result();
     void compute();
-    bool test();
+    bool test(bool verbose);
 
   private:
     double *x_mat, *r_mat;

--- a/numpy/linalg/det.cc
+++ b/numpy/linalg/det.cc
@@ -60,7 +60,7 @@ void Det::compute() {
     result = t;
 }
 
-bool Det::test() {
+bool Det::test(bool verbose) {
     clean_args();
     make_args(test_size);
     memcpy(x_mat, x_mat_test, mat_size * sizeof(*x_mat));

--- a/numpy/linalg/det.h
+++ b/numpy/linalg/det.h
@@ -13,7 +13,7 @@ class Det : public Bench {
     void make_args(int size);
     void copy_args();
     void clean_args();
-    bool test();
+    bool test(bool verbose);
     void print_args();
     void print_result();
     void compute();

--- a/numpy/linalg/dot.cc
+++ b/numpy/linalg/dot.cc
@@ -68,7 +68,7 @@ void Dot::compute() {
                 a_mat, k, b_mat, n, beta, r_mat, n);
 }
 
-bool Dot::test() {
+bool Dot::test(bool verbose) {
     clean_args();
     make_args(test_size);
     memcpy(a_mat, a_mat_test, m * k * sizeof(*a_mat));

--- a/numpy/linalg/dot.h
+++ b/numpy/linalg/dot.h
@@ -13,7 +13,7 @@ class Dot : public Bench {
     void make_args(int size);
     void copy_args();
     void clean_args();
-    bool test();
+    bool test(bool verbose);
     void print_args();
     void print_result();
     void compute();

--- a/numpy/linalg/eig.cc
+++ b/numpy/linalg/eig.cc
@@ -114,7 +114,7 @@ void Eig::compute() {
     }
 }
 
-bool Eig::test() {
+bool Eig::test(bool verbose) {
     clean_args();
     make_args(test_size);
     memcpy(a_mat, a_mat_test, mat_size * sizeof(*a_mat));

--- a/numpy/linalg/eig.h
+++ b/numpy/linalg/eig.h
@@ -14,7 +14,7 @@ class Eig : public Bench {
     void make_args(int size);
     void copy_args();
     void clean_args();
-    bool test();
+    bool test(bool verbose);
     void print_args();
     void print_result();
     void compute();

--- a/numpy/linalg/inv.cc
+++ b/numpy/linalg/inv.cc
@@ -13,22 +13,16 @@ static const int test_size = 5;
 Inv::Inv() {
     x_mat = 0;
     x_mat_init = 0;
-    r_mat = 0;
-    identity = 0;
     ipiv = 0;
 }
 
 void Inv::clean_args() {
-    if (r_mat)
-        mkl_free(r_mat);
     if (ipiv)
         mkl_free(ipiv);
     if (x_mat)
         mkl_free(x_mat);
     if (x_mat_init)
         mkl_free(x_mat_init);
-    if (identity)
-        mkl_free(identity);
 }
 
 Inv::~Inv() {

--- a/numpy/linalg/inv.cc
+++ b/numpy/linalg/inv.cc
@@ -62,7 +62,7 @@ void Inv::compute() {
     dgetri(&n, x_mat, &lda, ipiv, &dlwork, &lwork, &info);
     assert(info == 0);
 
-    lwork = (int) dlwork;
+    lwork = (int) (1.01 * dlwork);
     double *work = make_mat(lwork);
     assert(work);
 
@@ -73,7 +73,7 @@ void Inv::compute() {
     mkl_free(work);
 }
 
-bool Inv::test() {
+bool Inv::test(bool verbose) {
     clean_args();
     make_args(test_size);
     copy_args();
@@ -99,6 +99,10 @@ bool Inv::test() {
     }
 
 cleanup:
+    if (verbose) {
+        std::cout << "A * A**-1 = (should be identity matrix)" << std::endl;
+        print_mat('c', c, n, n);
+    }
     mkl_free(c);
     return identity;
 }

--- a/numpy/linalg/inv.h
+++ b/numpy/linalg/inv.h
@@ -13,7 +13,7 @@ class Inv : public Bench {
     void make_args(int size);
     void copy_args();
     void clean_args();
-    bool test();
+    bool test(bool verbose);
     void print_args();
     void print_result();
     void compute();

--- a/numpy/linalg/inv.h
+++ b/numpy/linalg/inv.h
@@ -19,7 +19,7 @@ class Inv : public Bench {
     void compute();
 
   private:
-    double *x_mat, *r_mat, *x_mat_init, *identity;
+    double *x_mat, *x_mat_init;
     int *ipiv;
     int n, lda, mat_size;
 };

--- a/numpy/linalg/linalg.cc
+++ b/numpy/linalg/linalg.cc
@@ -128,12 +128,17 @@ int main(int argc, char *argv[]) {
         Bench *real_bench = all_benches[bench];
 
         if (test) {
+            if (verbose)
+                std::cout << "---" << std::endl;
+
             if (!real_bench->test(verbose)) {
-                std::cout << "FAIL: " << bench << std::endl;
+                std::cout << "FAIL: " << bench;
                 return_value = 1;
             } else {
-                std::cout << "pass: " << bench << std::endl;
+                std::cout << "pass: " << bench;
             }
+            std::cout << std::endl;
+
             if (verbose) {
                 real_bench->print_args();
                 real_bench->print_result();
@@ -145,13 +150,13 @@ int main(int argc, char *argv[]) {
         if (verbose)
             real_bench->print_args();
 
+        // warm up
+        real_bench->copy_args();
+        real_bench->compute();
+
         for (int i = 0; i < samples; i++) {
 
             std::chrono::duration<double> timedelta(0.0);
-
-            // warm up
-            real_bench->copy_args();
-            real_bench->compute();
 
             for (int j = 0; j < reps; j++) {
                 real_bench->copy_args();

--- a/numpy/linalg/linalg.cc
+++ b/numpy/linalg/linalg.cc
@@ -128,7 +128,7 @@ int main(int argc, char *argv[]) {
         Bench *real_bench = all_benches[bench];
 
         if (test) {
-            if (!real_bench->test()) {
+            if (!real_bench->test(verbose)) {
                 std::cout << "FAIL: " << bench << std::endl;
                 return_value = 1;
             } else {

--- a/numpy/linalg/lu.cc
+++ b/numpy/linalg/lu.cc
@@ -111,7 +111,7 @@ void LU::compute() {
     assert(info == 0);
 }
 
-bool LU::test() {
+bool LU::test(bool verbose) {
     clean_args();
     make_args(test_size);
     memcpy(x_mat, x_mat_test, mat_size * sizeof(*x_mat));

--- a/numpy/linalg/lu.cc
+++ b/numpy/linalg/lu.cc
@@ -86,6 +86,7 @@ void LU::compute() {
     memset(u_mat, 0, u_size * sizeof(double));
 
     // extract L and U matrix elements from r_mat
+    // https://github.com/scipy/scipy/blob/maintenance/1.3.x/scipy/linalg/src/lu.f#L31-L45
     for (int j = 0; j < mn_min; j++) {
         l_mat[j * ld_l + j] = 1.;
 #pragma ivdep
@@ -108,12 +109,13 @@ void LU::compute() {
         }
     }
 
-    // permute_l=True
-    // make a diagonal matrix (m,m)
+    // permute_l=False
+    // make a diagonal matrix (m,m)...
     memset(p_mat, 0, p_size * sizeof(double));
     for (int i = 0; i < m; i++)
         p_mat[i * (m + 1)] = 1.0;
 
+    // ...and permute that matrix instead of L
     static const int one = 1, neg_one = -1;
     dlaswp(&m, p_mat, &m, &one, &mn_min, ipiv, &neg_one);
     assert(info == 0);

--- a/numpy/linalg/lu.cc
+++ b/numpy/linalg/lu.cc
@@ -75,7 +75,8 @@ void LU::copy_args() {
 
 void LU::compute() {
     // compute pivoted lu decomposition
-    int info = LAPACKE_dgetrf(LAPACK_COL_MAJOR, m, n, r_mat, lda, ipiv);
+    int info;
+    dgetrf(&m, &n, r_mat, &lda, ipiv, &info);
     assert(info == 0);
 
     int ld_l = m;
@@ -85,29 +86,36 @@ void LU::compute() {
     memset(u_mat, 0, u_size * sizeof(double));
 
     // extract L and U matrix elements from r_mat
+    for (int j = 0; j < mn_min; j++) {
+        l_mat[j * ld_l + j] = 1.;
 #pragma ivdep
-    for (int i = 0; i < m; i++) {
-#pragma ivdep
-        for (int j = 0; j < n; j++) {
-            if (j < mn_min) {
-                if (i == j) {
-                    l_mat[j * ld_l + i] = 1.0;
-                } else if (i > j) {
-                    l_mat[j * ld_l + i] = r_mat[j * lda + i];
-                }
-            }
-            if (i < mn_min && i <= j) {
-                u_mat[j * ld_u + i] = r_mat[j * lda + i];
-            }
+        for (int i = j + 1; i < m; i++) {
+            l_mat[j * ld_l + i] = r_mat[j * lda + i];
         }
     }
 
+    for (int j = 0; j < mn_min; j++) {
+#pragma ivdep
+        for (int i = 0; i <= j; i++) {
+            u_mat[j * ld_u + i] = r_mat[j * lda + i];
+        }
+    }
+
+    for (int j = mn_min; j < n; j++) {
+#pragma ivdep
+        for (int i = 0; i < mn_min; i++) {
+            u_mat[j * ld_u + i] = r_mat[j * lda + i];
+        }
+    }
+
+    // permute_l=True
     // make a diagonal matrix (m,m)
     memset(p_mat, 0, p_size * sizeof(double));
     for (int i = 0; i < m; i++)
         p_mat[i * (m + 1)] = 1.0;
 
-    info = LAPACKE_dlaswp(LAPACK_COL_MAJOR, m, p_mat, m, 1, mn_min, ipiv, -1);
+    static const int one = 1, neg_one = -1;
+    dlaswp(&m, p_mat, &m, &one, &mn_min, ipiv, &neg_one);
     assert(info == 0);
 }
 

--- a/numpy/linalg/lu.h
+++ b/numpy/linalg/lu.h
@@ -13,7 +13,7 @@ class LU : public Bench {
     void make_args(int size);
     void copy_args();
     void clean_args();
-    bool test();
+    bool test(bool verbose);
     void print_args();
     void print_result();
     void compute();

--- a/numpy/linalg/qr.cc
+++ b/numpy/linalg/qr.cc
@@ -70,7 +70,7 @@ void QR::compute() {
     }
 }
 
-bool QR::test() {
+bool QR::test(bool verbose) {
     clean_args();
     make_args(test_size);
     memcpy(x_mat_init, x_mat_test, mat_size * sizeof(*x_mat));

--- a/numpy/linalg/qr.h
+++ b/numpy/linalg/qr.h
@@ -13,7 +13,7 @@ class QR : public Bench {
     void make_args(int size);
     void copy_args();
     void clean_args();
-    bool test();
+    bool test(bool verbose);
     void print_args();
     void print_result();
     void compute();

--- a/numpy/linalg/svd.cc
+++ b/numpy/linalg/svd.cc
@@ -65,7 +65,7 @@ void SVD::compute() {
     assert(info == 0);
 }
 
-bool SVD::test() {
+bool SVD::test(bool verbose) {
     clean_args();
     make_args(test_size);
     memcpy(a_mat, x_mat_test, mat_size * sizeof(*a_mat));

--- a/numpy/linalg/svd.h
+++ b/numpy/linalg/svd.h
@@ -13,7 +13,7 @@ class SVD : public Bench {
     void make_args(int size);
     void copy_args();
     void clean_args();
-    bool test();
+    bool test(bool verbose);
     void print_args();
     void print_result();
     void compute();


### PR DESCRIPTION
- inv: use `dgetrf` and `dgetri` instead of `dgesv`
- cholesky: move copy to inside compute, mimic scipy's loops, use `dsyrk` instead of `dgemm` for initialization
- lu: split for-loops as in scipy
- inv, cholesky: remove hardcoded tests and verify mathematically
- runner: improve `-t -v` formatting, only warm-up once